### PR TITLE
Fix install fail when Python version >= 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9 ]
+        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
 
     steps:
       - uses: actions/checkout@v2
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9 ]
+        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
 
     steps:
       - uses: actions/checkout@v2
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9 ]
+        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
 
     steps:
       - uses: actions/checkout@v2
@@ -122,7 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9 ]
+        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
 
     steps:
       - uses: actions/checkout@v2
@@ -146,7 +146,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9 ]
+        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
 
     steps:
       - uses: actions/checkout@v2
@@ -186,7 +186,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9 ]
+        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}
@@ -211,7 +211,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9 ]
+        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
 
     steps:
       - uses: actions/checkout@v2
@@ -237,7 +237,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9 ]
+        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
 
     steps:
       - uses: actions/checkout@v2
@@ -263,7 +263,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9 ]
+        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
 
     steps:
       - uses: actions/checkout@v2
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
 
     steps:
       - uses: actions/checkout@v2
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
 
     steps:
       - uses: actions/checkout@v2
@@ -122,7 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
 
     steps:
       - uses: actions/checkout@v2
@@ -146,7 +146,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
 
     steps:
       - uses: actions/checkout@v2
@@ -186,7 +186,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}
@@ -211,7 +211,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
 
     steps:
       - uses: actions/checkout@v2
@@ -237,7 +237,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
 
     steps:
       - uses: actions/checkout@v2
@@ -263,7 +263,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file documents changes to [fastapi-mvc](https://github.com/rszamszur/fastap
 
 ## Unreleased
 
+### Fixed
+
+* New project cannot install with Python version > 3.10 [#60](https://github.com/rszamszur/fastapi-mvc/issues/60). PR [#61](https://github.com/rszamszur/fastapi-mvc/pull/61)
+
 ### Features
 
 * Add nix shell config for local development environment [#57](https://github.com/rszamszur/fastapi-mvc/issues/57). PR [#58](https://github.com/rszamszur/fastapi-mvc/pull/58)

--- a/build/install.sh
+++ b/build/install.sh
@@ -21,7 +21,7 @@ if [[ $PYTHON == "NOT_SET" ]]; then
 fi
 
 PYTHON_VERSION=$($PYTHON -V 2>&1 | grep -Eo '([0-9]+\.[0-9]+\.[0-9]+)$')
-if [[ ${PYTHON_VERSION} < "3.7.0" ]]; then
+if [[ ${PYTHON_VERSION} < "3.7.0" && ${PYTHON_VERSION} < "3.10.0" ]]; then
   echo "[install] Python version 3.7.0 or higher is required."
   exit 1
 fi

--- a/build/install.sh
+++ b/build/install.sh
@@ -20,8 +20,9 @@ if [[ $PYTHON == "NOT_SET" ]]; then
   fi
 fi
 
-PYTHON_VERSION=$($PYTHON -V 2>&1 | grep -Eo '([0-9]+\.[0-9]+\.[0-9]+)$')
-if [[ ${PYTHON_VERSION} < "3.7.0" && ${PYTHON_VERSION} < "3.10.0" ]]; then
+PYTHON_MAJOR_VERSION=$($PYTHON -c 'import sys; print(sys.version_info[0])')
+PYTHON_MINOR_VERSION=$($PYTHON -c 'import sys; print(sys.version_info[1])')
+if [[ "$PYTHON_MAJOR_VERSION" -lt 3 ]] || [[ "$PYTHON_MINOR_VERSION" -lt 7 ]]; then
   echo "[install] Python version 3.7.0 or higher is required."
   exit 1
 fi

--- a/fastapi_mvc/template/{{cookiecutter.folder_name}}/.github/workflows/main.yml
+++ b/fastapi_mvc/template/{{cookiecutter.folder_name}}/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9 ]
+        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
 
     steps:
       - uses: actions/checkout@v2
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9 ]
+        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
 
     steps:
       - uses: actions/checkout@v2
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9 ]
+        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
 
     steps:
       - uses: actions/checkout@v2
@@ -122,7 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9 ]
+        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
 
     steps:
       - uses: actions/checkout@v2
@@ -146,7 +146,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9 ]
+        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/fastapi_mvc/template/{{cookiecutter.folder_name}}/.github/workflows/main.yml
+++ b/fastapi_mvc/template/{{cookiecutter.folder_name}}/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
 
     steps:
       - uses: actions/checkout@v2
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
 
     steps:
       - uses: actions/checkout@v2
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
 
     steps:
       - uses: actions/checkout@v2
@@ -122,7 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
 
     steps:
       - uses: actions/checkout@v2
@@ -146,7 +146,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
 
     steps:
       - uses: actions/checkout@v2

--- a/fastapi_mvc/template/{{cookiecutter.folder_name}}/build/install.sh
+++ b/fastapi_mvc/template/{{cookiecutter.folder_name}}/build/install.sh
@@ -20,8 +20,9 @@ if [[ $PYTHON == "NOT_SET" ]]; then
   fi
 fi
 
-PYTHON_VERSION=$($PYTHON -V 2>&1 | grep -Eo '([0-9]+\.[0-9]+\.[0-9]+)$')
-if [[ ${PYTHON_VERSION} < "3.7.0" ]]; then
+PYTHON_MAJOR_VERSION=$($PYTHON -c 'import sys; print(sys.version_info[0])')
+PYTHON_MINOR_VERSION=$($PYTHON -c 'import sys; print(sys.version_info[1])')
+if [[ "$PYTHON_MAJOR_VERSION" -lt 3 ]] || [[ "$PYTHON_MINOR_VERSION" -lt 7 ]]; then
   echo "[install] Python version 3.7.0 or higher is required."
   exit 1
 fi


### PR DESCRIPTION
A bash condition leads to Python 3.10 being "lower" than Python 3.7, thus the installation of fastapi-mvc would fail.

**Checklist**:

- [x] Added tests for changed code where applicable.
- [x] Documentation reflects the changes where applicable.
- [x] Updated the `CHANGELOG.md` file with your changes.
- [x] My PR is ready to review.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to help you, not to deter you from contributing! -->

**Resolves: #60**

**Description of the changes being introduced by the pull request**: The python version bash condition is changed so Python version >=10 should also pass.
